### PR TITLE
add file comments in a prettier-compliant way

### DIFF
--- a/main.js
+++ b/main.js
@@ -24,9 +24,9 @@ function ignoreError(errors, file, filePath) {
 
     uniqueIds = [...new Set([...ruleIds, ...existing])];
 
-    writeFileSync(filePath, file.replace(/^.*\n/, `{{!-- template-lint-disable ${uniqueIds.join(' ')} --}}\n`));
+    writeFileSync(filePath, file.replace(/^.*\n/, `{{! template-lint-disable ${uniqueIds.join(' ')} }}\n`));
   } else {
-    writeFileSync(filePath, `{{!-- template-lint-disable ${uniqueIds.join(' ')} --}}\n${file}`);
+    writeFileSync(filePath, `{{! template-lint-disable ${uniqueIds.join(' ')} }}\n${file}`);
   }
 }
 


### PR DESCRIPTION
apparently the new prettier config prefers hbs comments in the style `{{! foo }}` instead of `{{!-- foo }}`. Who knew 🤷 