### PR TITLE
Fix issue caused by no gaps in comments

### DIFF
--- a/main.js
+++ b/main.js
@@ -71,10 +71,12 @@ export function list(directory) {
       return;
     }
 
-    const matched = firstLine.match(/template-lint-disable(.*) (--)?\}\}/);
+    const matched = firstLine.match(/template-lint-disable(.*)(--)?\}\}/);
 
     const ignoreRules = matched[1].split(' ')
       .map(item => item.trim())
+      // remove trailing -- from when there is no gaps in comments
+      .map(item => item.replace(/--$/, ''))
       .filter(item => item.length);
 
     ignoreRules.forEach((rule) => {

--- a/test/fixtures/list/addon/templates/components/notification-thingy.hbs
+++ b/test/fixtures/list/addon/templates/components/notification-thingy.hbs
@@ -1,0 +1,1 @@
+{{!template-lint-disable no-log}}

--- a/test/fixtures/list/addon/templates/components/notification-yoke.hbs
+++ b/test/fixtures/list/addon/templates/components/notification-yoke.hbs
@@ -1,0 +1,1 @@
+{{!--template-lint-disable no-log--}}

--- a/test/list.js
+++ b/test/list.js
@@ -33,7 +33,11 @@ describe('list function', function () {
         'app/templates/author.hbs',
         'tests/dummy/app/templates/application.hbs',
       ],
-      'no-log': ['app/templates/error.hbs'],
+      'no-log': [
+        'addon/templates/components/notification-thingy.hbs',
+        'addon/templates/components/notification-yoke.hbs',
+        'app/templates/error.hbs',
+      ],
       'no-unbalanced-curlies': ['tests/dummy/app/templates/application.hbs'],
       'require-button-type': ['tests/dummy/app/templates/application.hbs'],
       'require-input-label': ['tests/dummy/app/templates/application.hbs'],


### PR DESCRIPTION
apparently it turns out that the following is a valid hbs comment: 

```
{{!template-lint-disable no-log}}
```

where I assumed that you needed the gaps 🙃  I've fixed this so it's not a problem any more 👍 