### PR TITLE
Add lib to discovery folders

### DIFF
--- a/main.mjs
+++ b/main.mjs
@@ -35,7 +35,7 @@ function ignoreError(errorInput, file, filePath) {
 
 // only passing the cwd in for testing purposes
 export async function ignoreAll(cwd = process.cwd()) {
-  const files = walkSync(cwd, { globs: ['app/**/*.hbs', 'addon/**/*.hbs', 'tests/**/*.hbs'] });
+  const files = walkSync(cwd, { globs: ['app/**/*.hbs', 'addon/**/*.hbs', 'tests/**/*.hbs', 'lib/**/*.hbs'] });
 
   let TemplateLinter;
 
@@ -75,7 +75,7 @@ export function list(directory) {
   const cwd = directory || process.cwd();
 
   const files = walkSync(cwd, {
-    globs: ['app/**/*.hbs', 'addon/**/*.hbs', 'tests/**/*.hbs'],
+    globs: ['app/**/*.hbs', 'addon/**/*.hbs', 'tests/**/*.hbs', 'lib/**/*.hbs'],
   });
 
   const output = {};


### PR DESCRIPTION
A project I'm working on has a sort of in-repo addon under `lib/`, which ember-template-lint finds and lints.
This PR adds `lib/` to the list of folders that lttf searches in until the discovery mechanism is updated to match e-t-l.