### PR TITLE
Accept ember-template-lint (peer dependency) in v5

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -31,7 +31,7 @@ jobs:
       fail-fast: false
       matrix:
         node-version: [14.x, 16.x, 18.x]
-        template-lint-version: [2, 3, 4]
+        template-lint-version: [2, 3, 4, 5]
 
     steps:
     - uses: actions/checkout@v2

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "tmp": "^0.0.33"
   },
   "peerDependencies": {
-    "ember-template-lint": "^2.0.0 || ^3.0.0 || ^4.0.0"
+    "ember-template-lint": "^2.0.0 || ^3.0.0 || ^4.0.0 || ^5.0.0"
   },
   "engines": {
     "node": "10.* || >= 12.*"


### PR DESCRIPTION
When upgrading Ember from 4.8 to 4.9 `ember-template-lint` gets updated in the default blueprint: https://github.com/ember-cli/ember-cli/compare/v4.8.0..v4.9.0#diff-e4c0828d65b51abb30d80befe6fe7870dc36a73dad0083a9dcbb09d48f58e1cfR55. 

It would be good to accept version 5 as a peer dependency.