### PR TITLE
drop support for ember-template-lint < 5

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -42,7 +42,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        template-lint-version: [2, 3, 4, 5]
+        template-lint-version: [5, 6]
 
     steps:
     - uses: actions/checkout@v4


### PR DESCRIPTION
Something strange is happening when I move to ESM only that I can't quite figure out 🤔 it seems to only affect older ember-template-lint versions so I think it's time to drop support for really old versions

See https://github.com/mansona/lint-to-the-future-ember-template/pull/35