### PR TITLE
reinstate support for older ember-template-lint versions

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -42,7 +42,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        template-lint-version: [5, 6]
+        template-lint-version: [2, 3, 4, 5, 6]
 
     steps:
     - uses: actions/checkout@v4

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "vitest": "^2.1.8"
   },
   "peerDependencies": {
-    "ember-template-lint": "^5.0.0 || ^6.0.0"
+    "ember-template-lint": "^2.0.0 || ^3.0.0 || ^4.0.0 || ^5.0.0 || ^6.0.0"
   },
   "packageManager": "pnpm@9.15.0+sha512.76e2379760a4328ec4415815bcd6628dee727af3779aaa4c914e3944156c4299921a89f976381ee107d41f12cfa4b66681ca9c718f0668fa0831ed4c6d8ba56c",
   "engines": {


### PR DESCRIPTION
I figured out why it wasn't working 🙈 this essentially reverts https://github.com/mansona/lint-to-the-future-ember-template/pull/36