### PR TITLE
Drop support for ember-template-lint @ 2, and support for ember-template-lint @ 7

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -42,7 +42,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        template-lint-version: [2, 3, 4, 5, 6]
+        template-lint-version: [3, 4, 5, 6, 7]
 
     steps:
     - uses: actions/checkout@v4


### PR DESCRIPTION


Related: https://github.com/mansona/lint-to-the-future-ember-template/pull/44